### PR TITLE
fix(project_assets): Add cache-control no-store header

### DIFF
--- a/src/project_assets/http/middleware/mod.rs
+++ b/src/project_assets/http/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod set_cache_control;

--- a/src/project_assets/http/middleware/set_cache_control.rs
+++ b/src/project_assets/http/middleware/set_cache_control.rs
@@ -1,0 +1,11 @@
+use http::HeaderValue;
+use tower_http::set_header::SetResponseHeaderLayer;
+
+/// Sets a cache-control response header indicating that responses should not be
+/// cached anywhere.
+pub fn set_cache_control() -> SetResponseHeaderLayer<HeaderValue> {
+    SetResponseHeaderLayer::overriding(
+        http::header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store"),
+    )
+}

--- a/src/project_assets/http/mod.rs
+++ b/src/project_assets/http/mod.rs
@@ -1,5 +1,6 @@
 mod error;
 mod extractors;
+mod middleware;
 mod route_handlers;
 mod router;
 mod state;

--- a/src/project_assets/http/router.rs
+++ b/src/project_assets/http/router.rs
@@ -10,6 +10,7 @@ use super::super::application::service::ProjectAssetService;
 use super::route_handlers;
 use super::state::State;
 use crate::common::domain::value_objects::ProjectId;
+use crate::project_assets::http::middleware::set_cache_control::set_cache_control;
 
 pub static ASSET_PATH: LazyLock<ParameterizedRoute> =
     LazyLock::new(|| ParameterizedRoute::new("/{project_id}/{*path}"));
@@ -26,6 +27,9 @@ pub fn build_router(project_asset_service: ProjectAssetService) -> Router {
     };
 
     Router::new()
-        .route(&ASSET_PATH, get(route_handlers::project_asset))
+        .route(
+            &ASSET_PATH,
+            get(route_handlers::project_asset).layer(set_cache_control()),
+        )
         .layer(Extension(state))
 }


### PR DESCRIPTION
We have found that both Chrome and Firefox don't handle the caching of this project data very well, especially for larger projects. The user experience is just better when the browser just fetches the data from the server.