### PR TITLE
Generalize AuthZ

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ tracing-subscriber = "0.3.19"
 url = "2.5.6"
 web-route = "0.2.4"
 
+# `fake` feature
+fake = { version = "4.4.0", optional = true, features = ["derive", "url", "http"] }
 
 [dev-dependencies]
 axum-test = "18.0.0"
@@ -64,6 +66,9 @@ mockall = "0.13.1"
 tempfile = "3.21.0"
 test-case = "3.3.1"
 web-route = { version = "0.2.4", features = ["fake"] }
+
+[features]
+fake = ["dep:fake"]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ web-route = "0.2.4"
 # `fake` feature
 fake = { version = "4.4.0", optional = true, features = ["derive", "url", "http"] }
 
+# `mock` feature
+mockall = { version = "0.13.1", optional = true }
+
 [dev-dependencies]
 axum-test = "18.0.0"
 fake = { version = "4.4.0", features = ["derive", "url", "http"] }
@@ -68,7 +71,12 @@ test-case = "3.3.1"
 web-route = { version = "0.2.4", features = ["fake"] }
 
 [features]
+# Expose implementation of `fake::Dummy` on structs and enums.
 fake = ["dep:fake"]
+# Expose mocking functionality externally.
+mock = ["dep:fake", "dep:mockall"]
+# Expose functionality useful for testing
+test = ["fake", "mock"]
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = "0.6"

--- a/src/authorization/domain/action.rs
+++ b/src/authorization/domain/action.rs
@@ -2,7 +2,7 @@
 ///
 /// Used for authorization purposes.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(test, derive(fake::Dummy))]
+#[cfg_attr(any(test, feature = "fake"), derive(fake::Dummy))]
 pub enum Action {
     Read,
     List,

--- a/src/authorization/domain/resource.rs
+++ b/src/authorization/domain/resource.rs
@@ -43,7 +43,7 @@ new_type![
 /// traits for testing purposes.
 ///
 /// I was struggling to get mockall to deal with the supertrait mocking.
-#[cfg(test)]
+#[cfg(any(test, feature = "mock"))]
 pub mod mocked_resource {
     use super::EmailAddress;
     use super::Group;

--- a/src/authorization/domain/resource.rs
+++ b/src/authorization/domain/resource.rs
@@ -30,14 +30,12 @@ pub trait ResourceInstance: Resource {
 new_type![
     /// The identifier of a resource type (type-level). E.g. a "user", a "group",
     /// a "file", etc.
-    #[cfg_attr(test, derive(fake::Dummy))]
     ResourceType(String)
 ];
 
 new_type![
     /// The identifier of a specific resource instance (instance-level). E.g. a
     /// user id, a group id, a file id, etc.
-    #[cfg_attr(test, derive(fake::Dummy))]
     ResourceIdentifier(String)
 ];
 

--- a/src/authorization/domain/resource.rs
+++ b/src/authorization/domain/resource.rs
@@ -2,11 +2,10 @@ use std::fmt::Debug;
 
 use crate::common::domain::Group;
 use crate::common::domain::utils::new_type::new_type;
+use crate::user::domain::EmailAddress;
 
 /// Defines a resource type that can be authorized against.
 pub trait Resource: Debug {
-    /// The groups that the resource belongs to. Currently, if a user is part of
-    /// the same group they are allowed do action the resource.
     fn resource_type(&self) -> ResourceType;
 }
 
@@ -16,19 +15,28 @@ pub trait ResourceInstance: Resource {
     /// Identifies the specific resource instance.
     fn resource_identifier(&self) -> ResourceIdentifier;
 
-    /// The groups that the resource belongs to. Currently, if a user is part of
-    /// the same group they are allowed do action the resource.
-    fn groups(&self) -> Vec<Group>;
+    /// The groups that the resource belongs to. Some resource types won't be
+    /// associated with groups, in this case this should return None. Currently,
+    /// if a user is part of the same group they are allowed do action the
+    /// resource.
+    fn groups(&self) -> Option<Vec<Group>>;
+
+    ///The email addresses of the users that have access to the resource. Some
+    /// resource types won't be associated with users, in this case this
+    /// should return None.
+    fn user_emails(&self) -> Option<Vec<EmailAddress>>;
 }
 
 new_type![
-    /// The identifier of a resource type (type-level).
+    /// The identifier of a resource type (type-level). E.g. a "user", a "group",
+    /// a "file", etc.
     #[cfg_attr(test, derive(fake::Dummy))]
     ResourceType(String)
 ];
 
 new_type![
-    /// The identifier of a specific resource instance (instance-level).
+    /// The identifier of a specific resource instance (instance-level). E.g. a
+    /// user id, a group id, a file id, etc.
     #[cfg_attr(test, derive(fake::Dummy))]
     ResourceIdentifier(String)
 ];
@@ -39,6 +47,7 @@ new_type![
 /// I was struggling to get mockall to deal with the supertrait mocking.
 #[cfg(test)]
 pub mod mocked_resource {
+    use super::EmailAddress;
     use super::Group;
     use super::Resource;
     use super::ResourceIdentifier;
@@ -49,7 +58,8 @@ pub mod mocked_resource {
     pub struct MockedResource {
         pub resource_type: ResourceType,
         pub resource_identifier: ResourceIdentifier,
-        pub groups: Vec<Group>,
+        pub groups: Option<Vec<Group>>,
+        pub user_emails: Option<Vec<EmailAddress>>,
     }
 
     impl Resource for MockedResource {
@@ -63,8 +73,12 @@ pub mod mocked_resource {
             self.resource_identifier.clone()
         }
 
-        fn groups(&self) -> Vec<Group> {
+        fn groups(&self) -> Option<Vec<Group>> {
             self.groups.clone()
+        }
+
+        fn user_emails(&self) -> Option<Vec<EmailAddress>> {
+            self.user_emails.clone()
         }
     }
 }

--- a/src/authorization/ports/authorization_engine.rs
+++ b/src/authorization/ports/authorization_engine.rs
@@ -8,7 +8,7 @@ use crate::user::domain::User;
 
 /// Defines the functionality that needs to be implemented for the application
 /// to perform authentication.
-#[cfg_attr(test, mockall::automock)]
+#[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 pub trait AuthorizationEngine: Debug + Send + Sync + 'static {
     /// Determines if a `user` should be authorized to perform the `action` on
     /// the specified resource type (type-level).

--- a/src/common/domain/group.rs
+++ b/src/common/domain/group.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 /// Represents groups that users and projects can be part of.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize, Serialize)]
-#[cfg_attr(test, derive(fake::Dummy))]
+#[cfg_attr(any(test, feature = "fake"), derive(fake::Dummy))]
 pub struct Group(String);
 
 impl Group {

--- a/src/common/domain/mod.rs
+++ b/src/common/domain/mod.rs
@@ -1,4 +1,5 @@
 pub mod group;
+pub mod resource_type;
 pub mod static_asset;
 pub mod utils;
 

--- a/src/common/domain/resource_type.rs
+++ b/src/common/domain/resource_type.rs
@@ -1,0 +1,8 @@
+//! Common definitions for resource types used across the application.
+//!
+//! Reduces the chance of `&str` matching errors.
+
+pub const PROJECT: &str = "project";
+pub const PROJECTS_DASHBOARD: &str = "projects-dashboard";
+pub const PROJECT_ASSET: &str = "project-asset";
+pub const POTREE_RENDER: &str = "potree-render";

--- a/src/common/domain/utils/new_type.rs
+++ b/src/common/domain/utils/new_type.rs
@@ -23,6 +23,7 @@
 /// ```
 ///
 /// [1]: https://github.com/ramosbugs/oauth2-rs/blob/main/src/types.rs
+#[macro_export]
 macro_rules! new_type {
     // Convenience pattern without an impl.
     (

--- a/src/common/domain/utils/new_type.rs
+++ b/src/common/domain/utils/new_type.rs
@@ -92,6 +92,7 @@ macro_rules! new_type {
     ) => {
         $(#[$attr])*
         #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+        #[cfg_attr(any(test, feature = "fake"), derive(fake::Dummy))]
         pub struct $name(
             $(#[$type_attr])*
             $type

--- a/src/project/domain/authorization.rs
+++ b/src/project/domain/authorization.rs
@@ -6,10 +6,12 @@ use crate::authorization::domain::resource::ResourceIdentifier;
 use crate::authorization::domain::resource::ResourceInstance;
 use crate::authorization::domain::resource::ResourceType;
 use crate::common::domain::Group;
+use crate::common::domain::resource_type;
+use crate::user::domain::EmailAddress;
 
 impl Resource for Project {
     fn resource_type(&self) -> crate::authorization::domain::resource::ResourceType {
-        ResourceType::new("project".to_owned())
+        ResourceType::new(resource_type::PROJECT.to_owned())
     }
 }
 
@@ -18,8 +20,12 @@ impl ResourceInstance for Project {
         ResourceIdentifier::new(self.id.to_string())
     }
 
-    fn groups(&self) -> Vec<Group> {
-        self.groups.clone()
+    fn groups(&self) -> Option<Vec<Group>> {
+        Some(self.groups.clone())
+    }
+
+    fn user_emails(&self) -> Option<Vec<EmailAddress>> {
+        None
     }
 }
 
@@ -29,6 +35,6 @@ pub struct ProjectTypeResource;
 
 impl Resource for ProjectTypeResource {
     fn resource_type(&self) -> crate::authorization::domain::resource::ResourceType {
-        ResourceType::new("project".to_owned())
+        ResourceType::new(resource_type::PROJECT.to_owned())
     }
 }

--- a/src/project/domain/mod.rs
+++ b/src/project/domain/mod.rs
@@ -5,7 +5,7 @@ use crate::common::domain::utils::new_type::new_type;
 
 /// Represents the metadata associated with a 3D model project.
 #[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(test, derive(fake::Dummy))]
+#[cfg_attr(any(test, feature = "fake"), derive(fake::Dummy))]
 pub struct Project {
     pub id: ProjectId,
 
@@ -22,14 +22,12 @@ pub struct Project {
 new_type![
     /// The unique identifying slug of a [`Project`].
     #[derive(serde::Deserialize, serde::Serialize)]
-    #[cfg_attr(test, derive(fake::Dummy))]
     ProjectId(String)
 ];
 
 new_type![
     /// The name of a [`Project`].
     #[derive(serde::Deserialize, serde::Serialize)]
-    #[cfg_attr(test, derive(fake::Dummy))]
     ProjectName(
         #[cfg_attr(test, dummy(faker = "fake::faker::name::en::Name()"))]
         String
@@ -39,6 +37,5 @@ new_type![
 new_type![
     /// A high-level description of a [`Project`]. Gives the user more context.
     #[derive(serde::Deserialize, serde::Serialize)]
-    #[cfg_attr(test, derive(fake::Dummy))]
     ProjectDescription(String)
 ];

--- a/src/project_asset/domain/authorization.rs
+++ b/src/project_asset/domain/authorization.rs
@@ -4,7 +4,10 @@ use crate::authorization::domain::resource::Resource;
 use crate::authorization::domain::resource::ResourceIdentifier;
 use crate::authorization::domain::resource::ResourceInstance;
 use crate::authorization::domain::resource::ResourceType;
+use crate::common::domain::Group;
+use crate::common::domain::resource_type;
 use crate::project::domain::Project;
+use crate::user::domain::EmailAddress;
 
 /// A struct that is used to provide the required authZ data to the
 /// authorization engine.
@@ -16,7 +19,7 @@ pub struct ProjectAssetResource<'a> {
 
 impl Resource for ProjectAssetResource<'_> {
     fn resource_type(&self) -> crate::authorization::domain::resource::ResourceType {
-        ResourceType::new("project_asset".to_owned())
+        ResourceType::new(resource_type::PROJECT_ASSET.to_owned())
     }
 }
 
@@ -25,7 +28,11 @@ impl ResourceInstance for ProjectAssetResource<'_> {
         ResourceIdentifier::new(self.asset_path.to_string_lossy().to_string())
     }
 
-    fn groups(&self) -> Vec<crate::common::domain::Group> {
-        self.associated_project.groups.clone()
+    fn groups(&self) -> Option<Vec<Group>> {
+        Some(self.associated_project.groups.clone())
+    }
+
+    fn user_emails(&self) -> Option<Vec<EmailAddress>> {
+        None
     }
 }

--- a/src/render/domain/authorization.rs
+++ b/src/render/domain/authorization.rs
@@ -2,7 +2,10 @@ use crate::authorization::domain::resource::Resource;
 use crate::authorization::domain::resource::ResourceIdentifier;
 use crate::authorization::domain::resource::ResourceInstance;
 use crate::authorization::domain::resource::ResourceType;
+use crate::common::domain::Group;
+use crate::common::domain::resource_type;
 use crate::project::domain::Project;
+use crate::user::domain::EmailAddress;
 
 /// A struct that is used to provide the required authZ data to the
 /// authorization engine for a potree render instance.
@@ -13,7 +16,7 @@ pub struct PotreeRenderResource<'a> {
 
 impl Resource for PotreeRenderResource<'_> {
     fn resource_type(&self) -> crate::authorization::domain::resource::ResourceType {
-        ResourceType::new("potree_render".to_owned())
+        ResourceType::new(resource_type::POTREE_RENDER.to_owned())
     }
 }
 
@@ -22,8 +25,12 @@ impl ResourceInstance for PotreeRenderResource<'_> {
         ResourceIdentifier::new(format!("potree render: {}", self.associated_project.name))
     }
 
-    fn groups(&self) -> Vec<crate::common::domain::Group> {
-        self.associated_project.groups.clone()
+    fn groups(&self) -> Option<Vec<Group>> {
+        Some(self.associated_project.groups.clone())
+    }
+
+    fn user_emails(&self) -> Option<Vec<EmailAddress>> {
+        None
     }
 }
 
@@ -34,6 +41,6 @@ pub struct ProjectDashboardResource;
 
 impl Resource for ProjectDashboardResource {
     fn resource_type(&self) -> crate::authorization::domain::resource::ResourceType {
-        ResourceType::new("projects_dashboard".to_owned())
+        ResourceType::new(resource_type::PROJECTS_DASHBOARD.to_owned())
     }
 }

--- a/src/user/domain/mod.rs
+++ b/src/user/domain/mod.rs
@@ -26,7 +26,7 @@ impl User {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "fake"))]
 impl User {
     pub fn dummy_admin() -> Self {
         use fake::Fake;

--- a/src/user/domain/mod.rs
+++ b/src/user/domain/mod.rs
@@ -8,7 +8,7 @@ use crate::common::domain::utils::new_type::new_type;
 
 /// Represents an authenticated user of the application.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
-#[cfg_attr(test, derive(fake::Dummy))]
+#[cfg_attr(any(test, feature = "fake"), derive(fake::Dummy))]
 pub struct User {
     pub id: UserId,
     pub name: UserName,
@@ -44,9 +44,8 @@ impl User {
 new_type![
     /// The name of a [`crate::domain::User`].
     #[derive(Deserialize, Serialize)]
-    #[cfg_attr(test, derive(fake::Dummy))]
     UserName(
-        #[cfg_attr(test, dummy(faker = "fake::faker::name::en::Name()"))]
+        #[cfg_attr(any(test, feature = "fake"), dummy(faker = "fake::faker::name::en::Name()"))]
         String
     )
 ];
@@ -56,9 +55,8 @@ new_type![
     ///
     /// > **Note:** This is not validated.
     #[derive(Deserialize, Serialize)]
-    #[cfg_attr(test, derive(fake::Dummy))]
     EmailAddress(
-        #[cfg_attr(test, dummy(faker = "fake::faker::internet::en::FreeEmail()"))]
+        #[cfg_attr(any(test, feature = "fake"), dummy(faker = "fake::faker::internet::en::FreeEmail()"))]
         String
     )
 ];
@@ -66,7 +64,6 @@ new_type![
 new_type![
     /// The unique id of a [`crate::domain::User`].
     #[derive(Deserialize, Serialize)]
-    #[cfg_attr(test, derive(fake::Dummy))]
     UserId(String)
 ];
 


### PR DESCRIPTION
- Generalizes authZ trait to handle user identifiers.
- Update visibility to make more functionality usable by external applications.